### PR TITLE
Fix index issue of make_predictions() (issue #284)

### DIFF
--- a/healthcareai/common/model_eval.py
+++ b/healthcareai/common/model_eval.py
@@ -147,7 +147,7 @@ def roc_plot_from_thresholds(roc_thresholds_by_model, save=False, debug=False):
     From a given dictionary of thresholds by model, create a ROC curve for each model
 
     Args:
-        pr_thresholds_by_model (dict): A dictionary of ROC thresholds by model name.
+        roc_thresholds_by_model (dict): A dictionary of ROC thresholds by model name.
         save (bool): False to display the image (default) or True to save it (but not display it)
         debug (bool): verbost output.
     """

--- a/healthcareai/trained_models/trained_supervised_model.py
+++ b/healthcareai/trained_models/trained_supervised_model.py
@@ -164,7 +164,7 @@ class TrainedSupervisedModel(object):
 
         # Create a new dataframe with the grain column from the original dataframe
         results = pd.DataFrame()
-        results[self.grain_column] = dataframe[[self.grain_column]]
+        results[self.grain_column] = dataframe[self.grain_column].values
         results['Prediction'] = y_predictions
 
         return results
@@ -268,7 +268,7 @@ class TrainedSupervisedModel(object):
             raise HealthcareAIError('Warning! The number of predictions does not match the number of rows.')
 
         # Add predictions column to dataframe
-        results['Prediction'] = predictions['Prediction']
+        results['Prediction'] = predictions['Prediction'].values
 
         return results
 


### PR DESCRIPTION
In the function make_predictions(), using results[self.grain_column] = dataframe[[self.grain_column]] to copy a column from a data frame will result in a bunch of NaNs. To get the correct index of grain columns, we just need to copy the values in the column of the data frame. And it's the same issue in the function make_predictions_with_k_factors().