### PR TITLE
Clean up model trainers

### DIFF
--- a/healthcareai/advanced_supvervised_model_trainer.py
+++ b/healthcareai/advanced_supvervised_model_trainer.py
@@ -207,9 +207,7 @@ class AdvancedSupervisedModelTrainer(object):
             performance_metrics = hcai_model_evaluation.calculate_binary_classification_metrics(
                 trained_sklearn_estimator,
                 self.X_test,
-                self.y_test,
-
-            )
+                self.y_test)
         elif self.model_type is 'regression':
             performance_metrics = hcai_model_evaluation.calculate_regression_metrics(trained_sklearn_estimator,
                                                                                      self.X_test, self.y_test)

--- a/healthcareai/supervised_model_trainer.py
+++ b/healthcareai/supervised_model_trainer.py
@@ -24,10 +24,8 @@ class SupervisedModelTrainer(object):
             grain_column (str): The name of the grain column
             verbose (bool): Set to true for verbose output. Defaults to False.
         """
-        self.grain_column = grain_column,
-        self.predicted_column = predicted_column,
-        self.grain_column = grain_column,
-        self.grain_column = grain_column,
+        self.predicted_column = predicted_column
+        self.grain_column = grain_column
 
         # Build the pipeline
         # TODO This pipeline may drop nulls in prediction rows if impute=False


### PR DESCRIPTION
Removes duplicate property settings, unnecessary commas, and empty lines from model trainers.