### PR TITLE
deal with mixed types in get_categorical_levels

### DIFF
--- a/healthcareai/common/get_categorical_levels.py
+++ b/healthcareai/common/get_categorical_levels.py
@@ -25,9 +25,20 @@ def get_categorical_levels(dataframe, columns_to_ignore):
 
     # Get the distribution of values for each categorical column
     for column in categorical_columns:
+        # Get the counts for each categorical variable
         value_distribution = dataframe[column].value_counts(sort=False)
+
         # Sort by the index to ensure the correct dummy is dropped in get_dummies(drop_first=True)
-        value_distribution.sort_index(inplace=True)  # get counts for each factor level
+        # Do this in several steps to deal with mixed data types (e.g. int and str) in object column
+        # 1. Convert to dataframe
+        value_distribution = value_distribution.to_frame('counts')
+        # 2. Add column consisting of index values as strings
+        value_distribution['str_index'] = value_distribution.index.map(str)
+        # 3. Sort using the index values
+        value_distribution.sort_values('str_index', inplace = True)
+        # 4. Extract the sorted counts as a Series
+        value_distribution = value_distribution['counts']
+
         total_count = value_distribution.values.sum()  # get the number of occurences for all levels of the factor
         # divide the factor level counts by the total number to get the factor level frequencies
         value_distribution *= 1 / total_count


### PR DESCRIPTION
I changed the code to treat values as strings for the purposes of sorting. However, the values are not actually converted. This code should probably be its own function, but I first wanted to get your eyes on it to see if it seems like a reasonable solution to the problem before writing unit tests.

The function `get_categorical_levels` works with columns of type object and category to begin with so I think it's safe to assume that there is at least one string in each column.

One of the main purposes of `get_categorical_levels` is to make sure the categories are ordered in a consistent way for dummification. When dealing with mixed types, the pandas `get_dummies` seems to sort the columns the same way. For example, compare the result of dummification
```
# Series with mixed types:
x = pd.Series(['zebra', 1, -2, 3, 'potato', 2, 3, 3])

# Result of dummification
pd.get_dummies(x)
```
to the newly added code
```
value_distribution = x.value_counts(sort=False)

# 1. Convert to dataframe
value_distribution = value_distribution.to_frame('counts')
# 2. Add column consisting of index values as strings
value_distribution['str_index'] = value_distribution.index.map(str)
# 3. Sort using the index values
value_distribution.sort_values('str_index', inplace = True)
# 4. Extract the sorted counts as a Series
value_distribution = value_distribution['counts']

# Counts sorted by index
value_distribution
```
