### PR TITLE
Shows an example of decorators to make code cleaner?

### DIFF
--- a/healthcareai/common/output.py
+++ b/healthcareai/common/output.py
@@ -1,0 +1,45 @@
+"""outputs.py contains functions that prints to stdout."""
+
+import inspect
+from functools import partial, wraps
+
+
+def trainer_output(func=None, *, debug=False):
+    """Trainer output decorator for functions that train models.
+
+    This is a decorator that can be applied to any functions, and it will output the model type, and training results.
+
+    Args:
+        func (function): Function to be applied with decorator.
+        debug (bool): Debug option true or false.
+        * (params): trainer_output arguments.
+
+    Returns:
+        trained_model, or function: returns trained_model when calls the function with no supplied function, and
+            returns a callable when supplied with arguments.
+
+    """
+
+    # This func is only None when extra arguments are supplied, we will return a callable instead, which will get run
+    # and goes to the def wrap. Handy way of using decorators with extra arguments.
+    if func is None:
+        return partial(trainer_output, debug=debug)
+
+    # Wrap around our function so that if debug is true, so we can print out inputs and outputs. The @wraps decorator
+    # helps copies the parent function's information, such as __name__, and input parameters.
+    @wraps(func)
+    def wrap(self, *args, **kwargs):
+        # Since we have decorated function and self at runtime, we can get the name of the model, and construct the name
+        # out of the function name. Then use self's model type to output the model type (regression or classification)
+        print("Training:" + " ".join(func.__name__.split("_")).title() + ", Type:" + self._advanced_trainer.model_type)
+        trained_model = func(self, *args, **kwargs)
+        trained_model.print_training_results()
+
+        # If debug is true, we can output the function name, default, argument, and returns.
+        if debug:
+            print("Function Name: {}, Function Defaults: {}, "
+                  "Function Args: {} {}, Function Return: {}".format(func.__name__, inspect.signature(func),
+                                                                     args, kwargs, trained_model))
+        return trained_model
+
+    return wrap

--- a/healthcareai/supervised_model_trainer.py
+++ b/healthcareai/supervised_model_trainer.py
@@ -1,12 +1,11 @@
 """Trains Supervised Models."""
 
-from contextlib import contextmanager
-
 import healthcareai.pipelines.data_preparation as hcai_pipelines
 import healthcareai.trained_models.trained_supervised_model as hcai_tsm
 import healthcareai.common.cardinality_checks as hcai_ordinality
 from healthcareai.advanced_supvervised_model_trainer import AdvancedSupervisedModelTrainer
 from healthcareai.common.get_categorical_levels import get_categorical_levels
+from healthcareai.common.output import trainer_output
 
 
 class SupervisedModelTrainer(object):
@@ -28,8 +27,8 @@ class SupervisedModelTrainer(object):
             dataframe (pandas.core.frame.DataFrame): The training data in a pandas dataframe
             predicted_column (str): The name of the prediction column
             model_type (str): the trainer type - 'classification' or 'regression'
-            impute (bool): True to impute data (mean of numeric columns and mode of categorical ones). False to drop rows
-                that contain any null values.
+            impute (bool): True to impute data (mean of numeric columns and mode of categorical ones). False to drop
+                rows that contain any null values.
             grain_column (str): The name of the grain column
             verbose (bool): Set to true for verbose output. Defaults to False.
         """
@@ -87,40 +86,31 @@ class SupervisedModelTrainer(object):
             TrainedSupervisedModel: A trained supervised model.
         """
         if self._advanced_trainer.model_type is 'classification':
-            return self.random_forest_classification(
-                feature_importance_limit=feature_importance_limit,
-                save_plot=save_plot)
+            return self.random_forest_classification(feature_importance_limit=feature_importance_limit,
+                                                     save_plot=save_plot)
         elif self._advanced_trainer.model_type is 'regression':
             return self.random_forest_regression()
 
+    @trainer_output
     def knn(self):
         """Train a knn model and print out the model performance metrics.
 
         Returns:
             TrainedSupervisedModel: A trained supervised model.
         """
-        with nice_training_output('KNN') as model:
-            model.trained_model = self._advanced_trainer.knn(
-                scoring_metric='roc_auc',
-                hyperparameter_grid=None,
-                randomized_search=True)
+        return self._advanced_trainer.knn(scoring_metric='roc_auc', hyperparameter_grid=None, randomized_search=True)
 
-            return model.trained_model
-
+    @trainer_output
     def random_forest_regression(self):
         """Train a random forest regression model and print out the model performance metrics.
 
         Returns:
             TrainedSupervisedModel: A trained supervised model.
         """
-        with nice_training_output('Random Forest Regression') as model:
-            model.trained_model = self._advanced_trainer.random_forest_regressor(
-                trees=200,
-                scoring_metric='neg_mean_squared_error',
-                randomized_search=True)
+        return self._advanced_trainer.random_forest_regressor(trees=200, scoring_metric='neg_mean_squared_error',
+                                                              randomized_search=True)
 
-            return model.trained_model
-
+    @trainer_output
     def random_forest_classification(self, feature_importance_limit=15, save_plot=False):
         """Train a random forest classification model, print performance metrics and show a feature importance plot.
 
@@ -132,51 +122,46 @@ class SupervisedModelTrainer(object):
         Returns:
             TrainedSupervisedModel: A trained supervised model.
         """
-        with nice_training_output('Random Forest Classification') as model:
-            model.trained_model = self._advanced_trainer.random_forest_classifier(
-                trees=200,
-                scoring_metric='roc_auc',
-                randomized_search=True)
+        model = self._advanced_trainer.random_forest_classifier(trees=200,
+                                                                scoring_metric='roc_auc',
+                                                                randomized_search=True)
 
-            # Save or show the feature importance graph
-            hcai_tsm.plot_rf_features_from_tsm(
-                model.trained_model,
-                self._advanced_trainer.x_train,
-                feature_limit=feature_importance_limit,
-                save=save_plot)
+        # Save or show the feature importance graph
+        hcai_tsm.plot_rf_features_from_tsm(model,
+                                           self._advanced_trainer.x_train,
+                                           feature_limit=feature_importance_limit,
+                                           save=save_plot)
 
-            return model.trained_model
+        return model
 
+    @trainer_output
     def logistic_regression(self):
         """Train a logistic regression model and print out the model performance metrics.
 
         Returns:
             TrainedSupervisedModel: A trained supervised model.
         """
-        with nice_training_output('Logistic Regression') as model:
-            model.trained_model = self._advanced_trainer.logistic_regression(randomized_search=False)
-            return model.trained_model
+        return self._advanced_trainer.logistic_regression(randomized_search=False)
 
+    @trainer_output
     def linear_regression(self):
         """Train a linear regression model and print out the model performance metrics.
 
         Returns:
             TrainedSupervisedModel: A trained supervised model.
         """
-        with nice_training_output('Linear Regression') as model:
-            model.trained_model = self._advanced_trainer.linear_regression(randomized_search=False)
-            return model.trained_model
+        return self._advanced_trainer.linear_regression(randomized_search=False)
 
+    @trainer_output
     def lasso_regression(self):
         """Train a lasso regression model and print out the model performance metrics.
 
         Returns:
             TrainedSupervisedModel: A trained supervised model.
         """
-        with nice_training_output('Lasso Regression') as model:
-            model.trained_model = self._advanced_trainer.lasso_regression(randomized_search=False)
-            return model.trained_model
+        return self._advanced_trainer.lasso_regression(randomized_search=False)
 
+    @trainer_output
     def ensemble(self):
         """Train a ensemble model and print out the model performance metrics.
 
@@ -184,54 +169,20 @@ class SupervisedModelTrainer(object):
             TrainedSupervisedModel: A trained supervised model.
         """
         # TODO consider making a scoring parameter (which will necessitate some more logic
-        with nice_training_output('ensemble {}'.format(self._advanced_trainer.model_type)) as model:
-            # Train the appropriate ensemble of models
-            if self._advanced_trainer.model_type is 'classification':
-                metric = 'roc_auc'
-                model.trained_model = self._advanced_trainer.ensemble_classification(scoring_metric=metric)
-            elif self._advanced_trainer.model_type is 'regression':
-                # TODO stub
-                metric = 'neg_mean_squared_error'
-                model.trained_model = self._advanced_trainer.ensemble_regression(scoring_metric=metric)
+        if self._advanced_trainer.model_type is 'classification':
+            metric = 'roc_auc'
+            model = self._advanced_trainer.ensemble_classification(scoring_metric=metric)
+        elif self._advanced_trainer.model_type is 'regression':
+            # TODO stub
+            metric = 'neg_mean_squared_error'
+            model = self._advanced_trainer.ensemble_regression(scoring_metric=metric)
 
-            print('Based on the scoring metric {}, the best algorithm found is: {}'.format(
-                metric,
-                model.trained_model.algorithm_name))
+        print('Based on the scoring metric {}, '
+              'the best algorithm found is: {}'.format(metric, model.algorithm_name))
 
-            return model.trained_model
+        return model
 
     @property
     def advanced_features(self):
         """Return the underlying AdvancedSupervisedModelTrainer instance. For advanced users only."""
         return self._advanced_trainer
-
-
-class ContextManagerModel(object):
-    """A tiny class used by the `model_training` context manager."""
-
-    def __init__(self, model_name, trained_model=None):
-        """Create a new instance."""
-        self.model_name = model_name
-        self.trained_model = trained_model
-
-
-@contextmanager
-def nice_training_output(model_name):
-    """
-    Wrap model training code with nice console output before and after training as a way to factor code down.
-
-    This allows all algorithms to have consistent console output while having custom training (or other) code.
-
-    Args:
-        model_name (str): The name of the model used for pretty printing.
-    """
-    # Instantiate a temporary Model object to facilitate the unique code in the context manager
-    temp_model = ContextManagerModel(model_name)
-
-    print('\nTraining {}'.format(temp_model.model_name))
-
-    # Give the model back to the context to allow for unique training code
-    yield temp_model
-
-    # Display the trained model metrics
-    temp_model.trained_model.print_training_results()

--- a/healthcareai/tests/test_trainer_decorator.py
+++ b/healthcareai/tests/test_trainer_decorator.py
@@ -1,12 +1,19 @@
 import unittest
 from healthcareai.supervised_model_trainer import SupervisedModelTrainer
 import healthcareai.datasets as hcai_datasets
+import sys
+from io import StringIO
 
 
 class TestTrainerDecorator(unittest.TestCase):
-    """
+
+    """Tests for the training decorator.
+
+    We will compare a decorated linear regression and a undecorated linear regression output. They should not be
+    the same.
 
     """
+
     def setUp(self):
         df = hcai_datasets.load_diabetes()
 
@@ -14,15 +21,28 @@ class TestTrainerDecorator(unittest.TestCase):
         columns_to_remove = ['PatientID']
         df.drop(columns_to_remove, axis=1, inplace=True)
 
-        self.classification_trainer = SupervisedModelTrainer(dataframe=df,
-                                                             predicted_column='ThirtyDayReadmitFLG',
-                                                             model_type='classification',
-                                                             impute=True,
-                                                             grain_column='PatientEncounterID',
-                                                             verbose=False)
+        self.regression_trainer = SupervisedModelTrainer(df,
+                                                         'SystolicBPNBR',
+                                                         'regression',
+                                                         grain_column='PatientEncounterID',
+                                                         impute=True,
+                                                         verbose=False)
 
-        self.classification_trainer.undecorated_lasso_regression = \
-            lambda myself: myself._advanced_trainer.lasso_regression(randomized_search=False)
+        def undecorated_lr(self):
+            return self._advanced_trainer.linear_regression(randomized_search=False)
+
+        self.regression_trainer.undecorated_lr = undecorated_lr.__get__(self.regression_trainer,
+                                                                        self.regression_trainer.__class__)
 
     def test_decorator(self):
-        model = self.classification_trainer.lasso_regression()
+        out = StringIO()
+        sys.stdout = out
+        self.regression_trainer.linear_regression()
+        decorated_output = out.getvalue().strip()
+
+        out = StringIO()
+        sys.stdout = out
+        self.regression_trainer.undecorated_lr()
+        undecorated_output = out.getvalue().strip()
+
+        assert decorated_output != undecorated_output


### PR DESCRIPTION
Instead of using the context manager, you can use decorators to make the code cleaner and easier to maintain, since you don't need to write additional logic to an original function.

Without the `with` clause, and an extra `class` to do book keeping, we can use a decorator to parse the function name, and then also get `self` to call extra functions when training ends, such as training outputs.

With a decorator, you can pass in extra functions such as `debug=True`, for example `@trainer_output(debug=True)`. With `debug=True`, we can check for the function arguments, function defaults, and function output.

I think the library can benefit greatly from `decorators`. Whenever we are writing boiler code, we can apply `function decorators`. If all of the classes's function requires the same boiler code, then we can write `class decorators`. We can just apply a `class decorator` to a `class`, and the `class decorator` will apply all the boiler code to all of it's `functions`.

Talking about cleaner code, and maintainability. I think the commons folder needs to be separated. There are azure, database, and all sorts of things. They need to go in their own respective folders.