### PR TITLE
Removed partial and debug option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ eliminated the need for .mdf fixtures on appveyor.
 - validate_catalyst_prediction_sam_connection made much more robust with tests.
 - Conda environment files cleaned up substantially, speeding up builds.
 - Release preparation notes moved out of README and into a separate doc.
+- Decorators for `supervised_model_trainer` is now simplified, and debug option is no longer an option.
 
 ### Fixed
 

--- a/healthcareai/common/trainer_output.py
+++ b/healthcareai/common/trainer_output.py
@@ -8,7 +8,7 @@ import inspect
 from functools import partial, wraps
 
 
-def trainer_output(func=None, *, debug=False):
+def trainer_output(func):
     """
     Trainer output decorator for functions that train models.
 
@@ -18,19 +18,10 @@ def trainer_output(func=None, *, debug=False):
 
     Args:
         func (function): Function to be applied with decorator.
-        debug (bool): Debug option true or false.
-        * (params): trainer_output arguments.
 
     Returns:
-        trained_model|function: returns trained_model when called without a
-        function, or returns a callable when supplied with arguments.
+        trained_model: returns trained_model
     """
-
-    if func is None:
-        # This func is only None when extra arguments are supplied, return a
-        # callable instead, which will get run and goes to the def wrap. Handy
-        # way of using decorators with extra arguments.
-        return partial(trainer_output, debug=debug)
 
     # Wrap around our function so that if debug is true, we can print out
     # inputs and outputs. The @wraps decorator copies the parent function's
@@ -48,18 +39,6 @@ def trainer_output(func=None, *, debug=False):
             self._advanced_trainer.model_type))
         trained_model = func(self, *args, **kwargs)
         trained_model.print_training_results()
-
-        # If debug is true, output the function name, default, argument, and
-        # returns.
-        if debug:
-            print("Function Name: {}, Function Defaults: {}, "
-                  "Function Args: {} {}, Function Return: {}".format(
-                func.__name__,
-                inspect.signature(func),
-                args,
-                kwargs,
-                trained_model))
-
         return trained_model
 
     return wrap


### PR DESCRIPTION
Partial and debug has been removed to provide a simpler interface for decorators.

Wrap can also be removed, however, require a way to get the function name.

You could add in a parameter that is called function name, however, I think it's better to have the wraps in there.