### PR TITLE
Better way to deal with verbose messages?

### DIFF
--- a/healthcareai/advanced_supvervised_model_trainer.py
+++ b/healthcareai/advanced_supvervised_model_trainer.py
@@ -1,6 +1,7 @@
 import sklearn
 import numpy as np
 import time
+from functools import partial
 
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 from sklearn.linear_model import LinearRegression, LogisticRegression, Lasso
@@ -60,7 +61,7 @@ class AdvancedSupervisedModelTrainer(object):
         self.pipeline = None
         self.original_column_names = original_column_names
         self.categorical_column_info = None
-
+        self._console_log = partial(print, "AdvancedSupervisedModelTrainer :: ") if verbose else lambda *a, **k: None
         self._console_log(
             'Shape and top 5 rows of original dataframe:\n{}\n{}'.format(self.dataframe.shape, self.dataframe.head()))
 
@@ -483,7 +484,3 @@ class AdvancedSupervisedModelTrainer(object):
         """
         if not self.is_classification:
             raise HealthcareAIError('A {} model can only be trained with a classification trainer.'.format(model_name))
-
-    def _console_log(self, message):
-        if self.verbose:
-            print('AdvancedSupervisedModelTrainer :: {}'.format(message))


### PR DESCRIPTION
You could use a `partial` (To include custom messages for the print function), and `lambda`, instead of a function that checks for verbose every time. I think this way is pythonic?

`self._console_log = partial(print, "AdvancedSupervisedModelTrainer :: ") if verbose else lambda *a, **k: None`

What happens is that `partial` creates a callable with the print function that already has a input argument. Think of it as `print("AdvancedSupervisedModelTrainer :: ")`. When you use the print function with another input variable. This creates a function with two arguments, namely, `print("AdvancedSupervisedModelTrainer :: ", "some other text")`, this would print out the two arguments in a single line.

Hence if verbose is true, it creates a print function that can be called and supplied with an initial message.

The reason you cannot do: `print("something") if verbose`, is that `print("verbose")` is already a function with supplied arguments, hence it's not a callable so you cannot call it anymore.

The `lambda` function will receive any inputs, and then do nothing if `verbose=False`.

You don't need to merge this pull request, it's just something to think about when sprinkling one liner if statements for verbose.