### PR TITLE
Null Percentage Bugfix

### DIFF
--- a/healthcareai/common/null_profiling.py
+++ b/healthcareai/common/null_profiling.py
@@ -1,0 +1,25 @@
+"""Null Profiling Utilities."""
+import pandas as pd
+from tabulate import tabulate
+
+
+def calculate_numeric_column_null_percentages(df):
+    """Calculate null percentages in numeric columns."""
+    numeric_df = df.select_dtypes(exclude=[object, 'category']).copy()
+
+    return calculate_column_null_percentages(numeric_df)
+
+
+def calculate_column_null_percentages(df):
+    """Calculate null percentages in all columns."""
+    nulls = df.isnull().sum()
+
+    return nulls / len(df)
+
+
+def print_numeric_null_percentages(df, null_header='Percent Null'):
+    """Print a nice table of null percentages by column."""
+    results = pd.DataFrame(calculate_numeric_column_null_percentages(df))
+    table = tabulate(results, headers=['Column', null_header],
+                     tablefmt='fancy_grid')
+    print(table)

--- a/healthcareai/common/transformers.py
+++ b/healthcareai/common/transformers.py
@@ -139,7 +139,7 @@ def _print_imputation_warning(df):
 
     if (nulls != 0).any():
         # Show warning if any nulls are found
-        print('\nNote: Numeric imputation will always occur when making'
+        print('\nNote: Numeric imputation will always occur when making '
               'predictions on new data - otherwise rows would be dropped, '
               'which would lead to missing predictions.')
 

--- a/healthcareai/common/transformers.py
+++ b/healthcareai/common/transformers.py
@@ -12,6 +12,7 @@ from imblearn.under_sampling import RandomUnderSampler
 from sklearn.preprocessing import StandardScaler
 
 import healthcareai.common.categorical_levels as hcai_cats
+import healthcareai.common.null_profiling as hcai_nulls
 
 
 class DataFrameImputer(TransformerMixin):
@@ -44,15 +45,7 @@ class DataFrameImputer(TransformerMixin):
         self.fill = self._calculate_imputed_filler_row(X)
 
         if self.verbose:
-            num_nans = sum(X.select_dtypes(
-                include=[np.number, 'category', object]).isnull().sum())
-            num_total = sum(X.select_dtypes(
-                include=[np.number, 'category', object]).count())
-            percentage_imputed = num_nans / num_total * 100
-            print('Percentage Imputed: {:.2%}'.format(percentage_imputed))
-            print('Note: Numeric imputation will always occur when making'
-                  'predictions on new data - otherwise rows would be dropped, '
-                  'which would lead to missing predictions.')
+            _print_imputation_warning(X)
 
         # return self for scikit compatibility
         return self
@@ -138,6 +131,23 @@ class DataFrameImputer(TransformerMixin):
     def _get_unique_factors_set(X, column):
         """Factors in a column as a set."""
         return set(X[column].unique())
+
+
+def _print_imputation_warning(df):
+    """Print a warning about imputed numeric columns if there are any."""
+    nulls = hcai_nulls.calculate_numeric_column_null_percentages(df)
+
+    if (nulls != 0).any():
+        # Show warning if any nulls are found
+        print('\nNote: Numeric imputation will always occur when making'
+              'predictions on new data - otherwise rows would be dropped, '
+              'which would lead to missing predictions.')
+
+        print('\nImputed values for numeric columns:')
+        hcai_nulls.print_numeric_null_percentages(
+            df,
+            null_header='Percent Imputed')
+        print('\n\n')
 
 
 class DataFrameConvertTargetToBinary(TransformerMixin):

--- a/healthcareai/pipelines/data_preparation.py
+++ b/healthcareai/pipelines/data_preparation.py
@@ -79,7 +79,7 @@ def prediction_pipeline(predicted_column, grain_column):
         ('remove_grain_column', DataframeColumnRemover(grain_column)),
         # TODO we need to think about making this optional to solve the problem
         # TODO of rare and very predictive values
-        ('imputation', DataFrameImputer(impute=True)),
+        ('imputation', DataFrameImputer(impute=True, verbose=False)),
         ('create_dummy_variables', DataFrameCreateDummyVariables(excluded_columns=[predicted_column])),
         ('null_row_filter', DataframeNullValueFilter(excluded_columns=[predicted_column])),
     ])

--- a/healthcareai/tests/helpers.py
+++ b/healthcareai/tests/helpers.py
@@ -1,4 +1,8 @@
 """Test helpers."""
+import unittest
+
+import numpy as np
+import pandas as pd
 from os import path
 
 
@@ -28,3 +32,100 @@ def assertBetween(self, minimum, maximum, value):
     """Fail if value is not between min and max (inclusive)."""
     self.assertGreaterEqual(value, minimum)
     self.assertLessEqual(value, maximum)
+
+
+def generate_known_numeric(length):
+    result = np.array([1 for x in range(length)])
+
+    for i in range(int(length / 4)):
+        result[i] = 2
+
+    return result
+
+
+def convert_all_columns_to_uint8(df, ignore=None):
+    """
+    Convert all columns to dtype uint8.
+
+    Useful for assertions involving pandas.get_dummies(), which outputs uint8
+
+    Args:
+        df (pd.core.frame.DataFrame):
+        ignore (str|list): columns to ignore
+
+    Returns:
+        pd.core.frame.DataFrame: transformed dataframe
+    """
+    if not isinstance(ignore, list):
+        ignore = [ignore]
+
+    # filtered_df = df[df.columns.difference(ignore)]
+    for col in df:
+        if col in ignore:
+            df[col] = df[col]
+        else:
+            df[col] = df[col].astype('uint8')
+
+    return df
+
+
+def assert_dataframes_identical(expected, result, verbose=False):
+    """
+    Asserts dataframes are identical in many ways.
+
+    1. Sort each because column order matters for equality checks
+    2. Check that column names are identical
+    3. Check each series is identical
+    4. Check the entire dataframe
+    """
+    expected = expected.sort_index(axis=1)
+    result = result.sort_index(axis=1)
+
+    test_case = unittest.TestCase()
+
+    if verbose:
+        _print_comparison(expected, result)
+
+    test_case.assertListEqual(list(expected.columns), list(result.columns))
+
+    for col in expected:
+        pd.testing.assert_series_equal(expected[col], result[col])
+
+    test_case.assertTrue(list(expected.dtypes) == list(result.dtypes))
+
+    pd.testing.assert_frame_equal(
+        expected, result,
+        check_dtype=True,
+        check_index_type=True,
+        check_column_type=True,
+        check_frame_type=True,
+        check_exact=True,
+        check_names=True,
+        check_datetimelike_compat=True,
+        check_categorical=True,
+        check_like=True)
+
+
+def assert_series_equal(expected, result, verbose=False):
+    """
+    Prepare for and run equality assertion.
+
+    1. Sort index
+    2. convert to object (because these can be mixed series and sometimes
+    pandas interprets them as numeric)
+    3. run assertion
+    """
+    expected.sort_index(axis=0, inplace=True)
+    result.sort_index(axis=0, inplace=True)
+    expected = expected.astype(object)
+    result = result.astype(object)
+
+    if verbose:
+        _print_comparison(expected, result)
+    pd.testing.assert_series_equal(expected, result)
+
+
+def _print_comparison(expected, result):
+    print('\n\n\nresult\n\n', result, '\n\nexpected\n\n', expected)
+    print('\n\n\nresult\n\n', result.dtypes, '\n\nexpected\n\n',
+          expected.dtypes)

--- a/healthcareai/tests/test_dataframe_transformers.py
+++ b/healthcareai/tests/test_dataframe_transformers.py
@@ -1,87 +1,12 @@
-import unittest
 import string
+import unittest
+
+import numpy as np
+import pandas as pd
 import random
 
-import pandas as pd
-import numpy as np
-
 import healthcareai.common.transformers as transformers
-
-
-def _convert_all_columns_to_uint8(df, ignore=None):
-    # pandas.get_dummies() outputs uint8
-    if not isinstance(ignore, list):
-        ignore = [ignore]
-
-    # filtered_df = df[df.columns.difference(ignore)]
-    for col in df:
-        if col in ignore:
-            df[col] = df[col]
-        else:
-            df[col] = df[col].astype('uint8')
-
-    return df
-
-
-def _assert_dataframes_identical(expected, result, verbose=False):
-    """
-    Asserts dataframes are identical in many ways.
-
-    1. Sort each because column order matters for equality checks
-    2. Check that column names are identical
-    3. Check each series is identical
-    4. Check the entire dataframe
-    """
-    expected = expected.sort_index(axis=1)
-    result = result.sort_index(axis=1)
-
-    test_case = unittest.TestCase()
-
-    if verbose:
-        _print_comparison(expected, result)
-
-    test_case.assertListEqual(list(expected.columns), list(result.columns))
-
-    for col in expected:
-        pd.testing.assert_series_equal(expected[col], result[col])
-
-    test_case.assertTrue(list(expected.dtypes) == list(result.dtypes))
-
-    pd.testing.assert_frame_equal(
-        expected, result,
-        check_dtype=True,
-        check_index_type=True,
-        check_column_type=True,
-        check_frame_type=True,
-        check_exact=True,
-        check_names=True,
-        check_datetimelike_compat=True,
-        check_categorical=True,
-        check_like=True)
-
-
-def _print_comparison(expected, result):
-    print('\n\n\nresult\n\n', result, '\n\nexpected\n\n', expected)
-    print('\n\n\nresult\n\n', result.dtypes, '\n\nexpected\n\n', expected.dtypes)
-
-
-def _assert_series_equal(expected, result, verbose=False):
-    """
-    Prepare for and run equality assertion.
-
-    1. Sort index
-    2. convert to object (because these can be mixed series and sometimes
-    pandas interprets them as numeric)
-    3. run assertion
-    """
-    expected.sort_index(axis=0, inplace=True)
-    result.sort_index(axis=0, inplace=True)
-    expected = expected.astype(object)
-    result = result.astype(object)
-
-    if verbose:
-        _print_comparison(expected, result)
-    pd.testing.assert_series_equal(expected, result)
+import healthcareai.tests.helpers as hcaihelpers
 
 
 class TestDataframeImputer(unittest.TestCase):
@@ -99,7 +24,7 @@ class TestDataframeImputer(unittest.TestCase):
             'binary': np.random.choice(['a', 'b'], row_count, p=[.90, .1]),
             'alphabet': self.alphabet,
             'numeric': random.sample(range(0, row_count), row_count),
-            'known_numeric': self.generate_known_numeric(row_count),
+            'known_numeric': hcaihelpers.generate_known_numeric(row_count),
             'color': self.generate_known_color(row_count)
         })
         self.numeric_mean = self.train_df['numeric'].mean()
@@ -114,15 +39,6 @@ class TestDataframeImputer(unittest.TestCase):
             categories=['red', 'green', 'blue'])
 
         self.imputer = transformers.DataFrameImputer().fit(self.train_df)
-
-    @staticmethod
-    def generate_known_numeric(length):
-        result = np.array([1 for x in range(length)])
-
-        for i in range(int(length / 4)):
-            result[i] = 2
-
-        return result
 
     @staticmethod
     def generate_known_color(length):
@@ -157,7 +73,7 @@ class TestDataframeImputer(unittest.TestCase):
         # Drop columns with unknown distributions
         result.drop(['id', 'alphabet'], inplace=True)
 
-        _assert_series_equal(expected, result, verbose=True)
+        hcaihelpers.assert_series_equal(expected, result)
 
     def test_false_returns_unmodified(self):
         """Assure that no imputation occurs."""
@@ -178,7 +94,7 @@ class TestDataframeImputer(unittest.TestCase):
         imputer = transformers.DataFrameImputer(impute=False).fit(df)
         result = imputer.transform(df)
 
-        _assert_dataframes_identical(expected, result, verbose=True)
+        hcaihelpers.assert_dataframes_identical(expected, result)
 
     def test_converts_object_to_category(self):
         df = pd.DataFrame({
@@ -192,7 +108,7 @@ class TestDataframeImputer(unittest.TestCase):
 
         result = transformers.DataFrameImputer().fit_transform(df)
 
-        _assert_dataframes_identical(expected, result)
+        hcaihelpers.assert_dataframes_identical(expected, result)
 
     def test_removes_nans(self):
         """This should remove numeric NaNs, and not categoricals ones."""
@@ -214,7 +130,7 @@ class TestDataframeImputer(unittest.TestCase):
         self.assertFalse(result['num1'].isnull().values.any())
         self.assertFalse(result['num2'].isnull().values.any())
 
-        _assert_dataframes_identical(expected, result, verbose=True)
+        hcaihelpers.assert_dataframes_identical(expected, result)
 
     def test_removes_nones(self):
         """This should remove numeric Nones, and not categorical ones."""
@@ -237,7 +153,7 @@ class TestDataframeImputer(unittest.TestCase):
         self.assertFalse(result['num1'].isnull().values.any())
         self.assertFalse(result['num2'].isnull().values.any())
 
-        _assert_dataframes_identical(expected, result)
+        hcaihelpers.assert_dataframes_identical(expected, result)
 
     def test_get_unseen_factors(self):
         """binary column is as expected and alphabet column has new levels."""
@@ -376,7 +292,7 @@ class TestDataframeImputer(unittest.TestCase):
 
         result = self.imputer.transform(prediction_df)
 
-        _assert_dataframes_identical(expected, result)
+        hcaihelpers.assert_dataframes_identical(expected, result)
 
 
 class TestDataFrameConvertTargetToBinary(unittest.TestCase):
@@ -390,7 +306,7 @@ class TestDataFrameConvertTargetToBinary(unittest.TestCase):
 
         result = transformers.DataFrameConvertTargetToBinary('regression', 'string_outcome').fit_transform(expected)
 
-        _assert_dataframes_identical(expected, result)
+        hcaihelpers.assert_dataframes_identical(expected, result)
 
     def test_converts_y_n_for_classification(self):
         df = pd.DataFrame({
@@ -409,7 +325,7 @@ class TestDataFrameConvertTargetToBinary(unittest.TestCase):
 
         result = transformers.DataFrameConvertTargetToBinary('classification', 'string_outcome').fit_transform(df)
 
-        _assert_dataframes_identical(expected, result)
+        hcaihelpers.assert_dataframes_identical(expected, result)
 
 
 class TestDataFrameCreateDummyVariables(unittest.TestCase):
@@ -478,7 +394,7 @@ class TestDataFrameCreateDummyVariables(unittest.TestCase):
 
         result = dummifier.transform(df)
 
-        _assert_dataframes_identical(expected, result)
+        hcaihelpers.assert_dataframes_identical(expected, result)
 
     def test_trinary_object_and_category(self):
         df = pd.DataFrame({
@@ -510,7 +426,7 @@ class TestDataFrameCreateDummyVariables(unittest.TestCase):
         result = transformers.DataFrameCreateDummyVariables(
             'id').fit_transform(df)
 
-        _assert_dataframes_identical(expected, result)
+        hcaihelpers.assert_dataframes_identical(expected, result)
 
     def test_remembers_unrepresented_categories(self):
         # TODO this is broken due to a pandas bug
@@ -548,7 +464,7 @@ class TestDataFrameCreateDummyVariables(unittest.TestCase):
         # trained = transformers.DataFrameCreateDummyVariables('id').fit(self.train_df)
         # result = trained.transform(prediction_df)
         #
-        # _assert_dataframes_identical(expected, result)
+        # hcaihelpers._assert_dataframes_identical(expected, result)
 
     def test_none_represented(self):
         prediction_df = pd.DataFrame({
@@ -591,12 +507,10 @@ class TestDataFrameCreateDummyVariables(unittest.TestCase):
             'numeric': [1, 2, 1],
         })
 
-        expected = _convert_all_columns_to_uint8(expected, ['id', 'numeric'])
+        expected = hcaihelpers.convert_all_columns_to_uint8(expected, ['id', 'numeric'])
         result = self.dummifier.transform(prediction_df)
 
-        _assert_dataframes_identical(expected, result)
-
-
+        hcaihelpers.assert_dataframes_identical(expected, result)
 
 
 class TestDataFrameConvertColumnToNumeric(unittest.TestCase):
@@ -613,7 +527,7 @@ class TestDataFrameConvertColumnToNumeric(unittest.TestCase):
         })
 
         result = transformers.DataFrameConvertColumnToNumeric('integer_strings').fit_transform(df)
-        _assert_dataframes_identical(expected, result)
+        hcaihelpers.assert_dataframes_identical(expected, result)
 
     def test_integer(self):
         df = pd.DataFrame({
@@ -627,7 +541,7 @@ class TestDataFrameConvertColumnToNumeric(unittest.TestCase):
 
         result = transformers.DataFrameConvertColumnToNumeric('numeric').fit_transform(df)
 
-        _assert_dataframes_identical(expected, result)
+        hcaihelpers.assert_dataframes_identical(expected, result)
 
 
 class TestDataframeUnderSampler(unittest.TestCase):
@@ -716,7 +630,7 @@ class TestRemovesNANs(unittest.TestCase):
              'c': [3, 4, 5, None, None],
              'd': [None, 8, 1, 3, None],
              'label': ['Y', 'N', 'Y', 'N', None]})
-        _assert_dataframes_identical(expected, result)
+        hcaihelpers.assert_dataframes_identical(expected, result)
 
 
 class TestFeatureScaling(unittest.TestCase):
@@ -746,10 +660,10 @@ class TestFeatureScaling(unittest.TestCase):
         feature_scaling = transformers.DataFrameFeatureScaling()
         df_final = feature_scaling.fit_transform(self.df).round(5)
 
-        _assert_dataframes_identical(expected.round(5), df_final)
+        hcaihelpers.assert_dataframes_identical(expected.round(5), df_final)
 
         df_reused = transformers.DataFrameFeatureScaling(reuse=feature_scaling).fit_transform(self.df_repeat).round(5)
-        _assert_dataframes_identical(expected.round(5), df_reused)
+        hcaihelpers.assert_dataframes_identical(expected.round(5), df_reused)
 
 
 if __name__ == '__main__':

--- a/healthcareai/tests/test_null_profiling.py
+++ b/healthcareai/tests/test_null_profiling.py
@@ -1,0 +1,59 @@
+"""Test Null Profiling."""
+
+import unittest
+
+import numpy as np
+import pandas as pd
+import random
+
+import healthcareai.tests.helpers as hcai_helpers
+import healthcareai.common.null_profiling as hcai_nulls
+
+
+class TestNullProfiling(unittest.TestCase):
+    def setUp(self):
+        rows = 100
+        df = pd.DataFrame({
+            'id': range(rows),
+            'binary': np.random.choice(['a', 'b'], rows, p=[.90, .1]),
+            'numeric': random.sample(range(0, rows), rows),
+        })
+        df['binary_cat'] = df['binary'].astype('category')
+        df['all_nan'] = np.NaN
+        df['half_null'] = [None if x % 2 == 0 else x for x in range(rows)]
+        df['quarter_null'] = [None if x % 4 == 0 else x for x in range(rows)]
+        df['three_quarter_null'] = [x if i % 4 == 0 else None for i, x in
+                                    enumerate(np.random.choice(['a', 'b'],
+                                                               rows))]
+        self.df = df
+
+    def test_calculate_column_null_percentage(self):
+        expected = pd.Series({
+            'id': 0,
+            'binary': 0,
+            'binary_cat': 0,
+            'numeric': 0,
+            'all_nan': 1,
+            'half_null': 0.5,
+            'quarter_null': 0.25,
+            'three_quarter_null': 0.75,
+        })
+
+        result = hcai_nulls.calculate_column_null_percentages(self.df)
+
+        self.assertIsInstance(result, pd.Series)
+        hcai_helpers.assert_series_equal(expected, result)
+
+    def test_calculate_numeric_column_null_percentage(self):
+        expected = pd.Series({
+            'id': 0,
+            'numeric': 0,
+            'all_nan': 1,
+            'half_null': 0.5,
+            'quarter_null': 0.25,
+        })
+
+        result = hcai_nulls.calculate_numeric_column_null_percentages(self.df)
+
+        self.assertIsInstance(result, pd.Series)
+        hcai_helpers.assert_series_equal(expected, result)


### PR DESCRIPTION
## Notes

This is a small PR going **into** 372.

## Fixed

* new null profiling module with a few tests
* replaced null calculation with new module
* moved series and frame assertions to tests helpers
* typo noted earlier

## Things to test

- [ ] imputation now prints a table of imputed values per column if any are found.
- [ ] warning should not have typo

## Expected Output:

```
Note: Numeric imputation will always occur when making predictions on new data - otherwise rows would be dropped, which would lead to missing predictions.

Imputed values for numeric columns:
╒═══════════════╤═══════════════════╕
│ Column        │   Percent Imputed │
╞═══════════════╪═══════════════════╡
│ SystolicBPNBR │             0.013 │
├───────────────┼───────────────────┤
│ LDLNBR        │             0.013 │
├───────────────┼───────────────────┤
│ A1CNBR        │             0.013 │
╘═══════════════╧═══════════════════╛
```
