### PR TITLE
PLEASE MERGE FIRST :: Missing category ignores target column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ in console output and on ROC/PR plots.
 - Getting started section of README vastly improved
 - Bug that was imputing prediction target data during trainig.
 - Predictions no longer fail when categorical factors present during training were missing in prediction.
+- Nulls in prediction column are now removed
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Imputation transformer now warns users about unseen factors during prediction use.
 - `SupervisedModelTrainer` now has additional properties: `class_labels` and `number_of_classes`
 - new test helpers for robust dataframe and series equality assertions
+- DataFrameImputer can now exclude columns.
 
 ### Changed
 

--- a/healthcareai/pipelines/data_preparation.py
+++ b/healthcareai/pipelines/data_preparation.py
@@ -42,7 +42,7 @@ def training_pipeline(predicted_column, grain_column, impute=True):
         # TODO of rare and very predictive values
         # Perform one of two basic imputation methods
         # TODO we need to think about making this optional to solve the problem of rare and very predictive values
-        ('imputation', DataFrameImputer(impute=impute, verbose=True)),
+        ('imputation', DataFrameImputer(impute=impute, excluded_columns=predicted_column, verbose=True)),
         ('create_dummy_variables', DataFrameCreateDummyVariables(excluded_columns=[predicted_column])),
         ('null_row_filter', DataframeNullValueFilter(excluded_columns=None)),
     ])
@@ -79,7 +79,7 @@ def prediction_pipeline(predicted_column, grain_column):
         ('remove_grain_column', DataframeColumnRemover(grain_column)),
         # TODO we need to think about making this optional to solve the problem
         # TODO of rare and very predictive values
-        ('imputation', DataFrameImputer(impute=True)),
+        ('imputation', DataFrameImputer(impute=True, excluded_columns=predicted_column)),
         ('create_dummy_variables', DataFrameCreateDummyVariables(excluded_columns=[predicted_column])),
         ('null_row_filter', DataframeNullValueFilter(excluded_columns=[predicted_column])),
     ])

--- a/healthcareai/tests/helpers.py
+++ b/healthcareai/tests/helpers.py
@@ -30,8 +30,10 @@ def fixture(file):
 
 def assertBetween(self, minimum, maximum, value):
     """Fail if value is not between min and max (inclusive)."""
-    self.assertGreaterEqual(value, minimum)
-    self.assertLessEqual(value, maximum)
+    test_case = unittest.TestCase()
+
+    test_case.assertGreaterEqual(value, minimum)
+    test_case.assertLessEqual(value, maximum)
 
 
 def generate_known_numeric(length):

--- a/healthcareai/tests/test_advanced_trainer.py
+++ b/healthcareai/tests/test_advanced_trainer.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 import pandas as pd
 
-from healthcareai.advanced_supvervised_model_trainer import _remove_nas_from_labels
+from healthcareai.advanced_supvervised_model_trainer import _remove_nulls_from_labels
 from healthcareai.trained_models.trained_supervised_model import TrainedSupervisedModel
 import healthcareai.datasets as hcai_datasets
 
@@ -46,20 +46,29 @@ class TestAdvancedSupervisedModelTrainer(unittest.TestCase):
             clean_classification_df, CLASSIFICATION,
             CLS_PRED_COL)
 
-    def test_remove_nones_from_series(self):
+    def test_remove_nones_and_nans_from_object_series(self):
         ser = pd.Series(['Y', 'N', 'Y', np.NaN, None])
         expected = pd.Series(['Y', 'N', 'Y'])
 
-        result = _remove_nas_from_labels(ser)
+        result = _remove_nulls_from_labels(ser)
 
         self.assertIsInstance(result, pd.Series)
         pd.testing.assert_series_equal(expected, result)
+
+    def test_remove_nones_from_object_series(self):
+        junkpile = pd.Series(['Y', 'N', 'Y', None, None]).as_matrix()
+        expected = pd.Series(['Y', 'N', 'Y']).as_matrix()
+
+        result = _remove_nulls_from_labels(junkpile)
+
+        self.assertIsInstance(result, np.ndarray)
+        self.assertTrue(np.array_equal(expected, result))
 
     def test_remove_nones_from_numpy_array(self):
         arr = np.array([1, 2, 3, np.NaN, None])
         expected = np.array([1, 2, 3])
 
-        result = _remove_nas_from_labels(arr)
+        result = _remove_nulls_from_labels(arr)
 
         self.assertIsInstance(result, np.ndarray)
         self.assertTrue(np.array_equal(expected, result))
@@ -69,7 +78,7 @@ class TestAdvancedSupervisedModelTrainer(unittest.TestCase):
         index = pd.Categorical(['Y', 'N', 'Maybe', np.NaN, None])
         expected = pd.Index(['Maybe', 'N', 'Y'])
 
-        result = _remove_nas_from_labels(index)
+        result = _remove_nulls_from_labels(index)
 
         self.assertIsInstance(result, pd.Index)
         pd.testing.assert_index_equal(expected, result)
@@ -218,7 +227,7 @@ class TestBinaryClassificationMetricValidation(unittest.TestCase):
     def test_is_binary_classifier_true(self):
         self.assertTrue(self.classification_trainer.is_binary_classification)
 
-    def test_class_labels_property(self):
+    def test_class_labels_strings(self):
         # set literal saves a function call to set()
         self.assertEqual({'Y', 'N'}, set(self.classification_trainer.class_labels))
 

--- a/healthcareai/tests/test_dataframe_transformers.py
+++ b/healthcareai/tests/test_dataframe_transformers.py
@@ -6,7 +6,9 @@ import pandas as pd
 import random
 
 import healthcareai.common.transformers as transformers
-import healthcareai.tests.helpers as hcaihelpers
+from healthcareai.tests.helpers import generate_known_numeric, \
+    assert_dataframes_identical, convert_all_columns_to_uint8, \
+    assert_series_equal
 
 
 class TestDataframeImputer(unittest.TestCase):
@@ -24,7 +26,7 @@ class TestDataframeImputer(unittest.TestCase):
             'binary': np.random.choice(['a', 'b'], row_count, p=[.90, .1]),
             'alphabet': self.alphabet,
             'numeric': random.sample(range(0, row_count), row_count),
-            'known_numeric': hcaihelpers.generate_known_numeric(row_count),
+            'known_numeric': generate_known_numeric(row_count),
             'color': self.generate_known_color(row_count)
         })
         self.numeric_mean = self.train_df['numeric'].mean()
@@ -73,7 +75,7 @@ class TestDataframeImputer(unittest.TestCase):
         # Drop columns with unknown distributions
         result.drop(['id', 'alphabet'], inplace=True)
 
-        hcaihelpers.assert_series_equal(expected, result)
+        assert_series_equal(expected, result)
 
     def test_false_returns_unmodified(self):
         """Assure that no imputation occurs."""
@@ -94,7 +96,7 @@ class TestDataframeImputer(unittest.TestCase):
         imputer = transformers.DataFrameImputer(impute=False).fit(df)
         result = imputer.transform(df)
 
-        hcaihelpers.assert_dataframes_identical(expected, result)
+        assert_dataframes_identical(expected, result)
 
     def test_converts_object_to_category(self):
         df = pd.DataFrame({
@@ -108,7 +110,7 @@ class TestDataframeImputer(unittest.TestCase):
 
         result = transformers.DataFrameImputer().fit_transform(df)
 
-        hcaihelpers.assert_dataframes_identical(expected, result)
+        assert_dataframes_identical(expected, result)
 
     def test_columns_to_impute(self):
         result = self.imputer._columns_to_impute(self.train_df)
@@ -149,7 +151,7 @@ class TestDataframeImputer(unittest.TestCase):
         result = imputer.fit_transform(df)
 
         self.assertFalse(result['num1'].isnull().values.any())
-        _assert_dataframes_identical(expected, result)
+        assert_dataframes_identical(expected, result)
 
     def test_single_exclusion_as_list(self):
         df = pd.DataFrame({
@@ -170,7 +172,7 @@ class TestDataframeImputer(unittest.TestCase):
         result = imputer.fit_transform(df)
 
         self.assertFalse(result['num1'].isnull().values.any())
-        _assert_dataframes_identical(expected, result)
+        assert_dataframes_identical(expected, result)
 
     def test_removes_nans(self):
         """This should remove numeric NaNs, and not categoricals ones."""
@@ -192,7 +194,7 @@ class TestDataframeImputer(unittest.TestCase):
         self.assertFalse(result['num1'].isnull().values.any())
         self.assertFalse(result['num2'].isnull().values.any())
 
-        hcaihelpers.assert_dataframes_identical(expected, result)
+        assert_dataframes_identical(expected, result)
 
     def test_removes_nones(self):
         """This should remove numeric Nones, and not categorical ones."""
@@ -215,7 +217,7 @@ class TestDataframeImputer(unittest.TestCase):
         self.assertFalse(result['num1'].isnull().values.any())
         self.assertFalse(result['num2'].isnull().values.any())
 
-        hcaihelpers.assert_dataframes_identical(expected, result)
+        assert_dataframes_identical(expected, result)
 
     def test_get_unseen_factors(self):
         """binary column is as expected and alphabet column has new levels."""
@@ -357,7 +359,7 @@ class TestDataframeImputer(unittest.TestCase):
         # imputer = transformers.DataFrameImputer().fit(prediction_df)
         result = self.imputer.transform(prediction_df)
 
-        hcaihelpers.assert_dataframes_identical(expected, result)
+        assert_dataframes_identical(expected, result)
 
 
 class TestDataFrameConvertTargetToBinary(unittest.TestCase):
@@ -371,7 +373,7 @@ class TestDataFrameConvertTargetToBinary(unittest.TestCase):
 
         result = transformers.DataFrameConvertTargetToBinary('regression', 'string_outcome').fit_transform(expected)
 
-        hcaihelpers.assert_dataframes_identical(expected, result)
+        assert_dataframes_identical(expected, result)
 
     def test_converts_y_n_for_classification(self):
         df = pd.DataFrame({
@@ -390,7 +392,7 @@ class TestDataFrameConvertTargetToBinary(unittest.TestCase):
 
         result = transformers.DataFrameConvertTargetToBinary('classification', 'string_outcome').fit_transform(df)
 
-        hcaihelpers.assert_dataframes_identical(expected, result)
+        assert_dataframes_identical(expected, result)
 
 
 class TestDataFrameCreateDummyVariables(unittest.TestCase):
@@ -459,7 +461,7 @@ class TestDataFrameCreateDummyVariables(unittest.TestCase):
 
         result = dummifier.transform(df)
 
-        hcaihelpers.assert_dataframes_identical(expected, result)
+        assert_dataframes_identical(expected, result)
 
     def test_trinary_object_and_category(self):
         df = pd.DataFrame({
@@ -491,7 +493,7 @@ class TestDataFrameCreateDummyVariables(unittest.TestCase):
         result = transformers.DataFrameCreateDummyVariables(
             'id').fit_transform(df)
 
-        hcaihelpers.assert_dataframes_identical(expected, result)
+        assert_dataframes_identical(expected, result)
 
     def test_remembers_unrepresented_categories(self):
         # TODO this is broken due to a pandas bug
@@ -529,7 +531,7 @@ class TestDataFrameCreateDummyVariables(unittest.TestCase):
         # trained = transformers.DataFrameCreateDummyVariables('id').fit(self.train_df)
         # result = trained.transform(prediction_df)
         #
-        # hcaihelpers._assert_dataframes_identical(expected, result)
+        # _assert_dataframes_identical(expected, result)
 
     def test_none_represented(self):
         prediction_df = pd.DataFrame({
@@ -572,10 +574,10 @@ class TestDataFrameCreateDummyVariables(unittest.TestCase):
             'numeric': [1, 2, 1],
         })
 
-        expected = hcaihelpers.convert_all_columns_to_uint8(expected, ['id', 'numeric'])
+        expected = convert_all_columns_to_uint8(expected, ['id', 'numeric'])
         result = self.dummifier.transform(prediction_df)
 
-        hcaihelpers.assert_dataframes_identical(expected, result)
+        assert_dataframes_identical(expected, result)
 
 
 class TestDataFrameConvertColumnToNumeric(unittest.TestCase):
@@ -592,7 +594,7 @@ class TestDataFrameConvertColumnToNumeric(unittest.TestCase):
         })
 
         result = transformers.DataFrameConvertColumnToNumeric('integer_strings').fit_transform(df)
-        hcaihelpers.assert_dataframes_identical(expected, result)
+        assert_dataframes_identical(expected, result)
 
     def test_integer(self):
         df = pd.DataFrame({
@@ -606,7 +608,7 @@ class TestDataFrameConvertColumnToNumeric(unittest.TestCase):
 
         result = transformers.DataFrameConvertColumnToNumeric('numeric').fit_transform(df)
 
-        hcaihelpers.assert_dataframes_identical(expected, result)
+        assert_dataframes_identical(expected, result)
 
 
 class TestDataframeUnderSampler(unittest.TestCase):
@@ -695,7 +697,7 @@ class TestRemovesNANs(unittest.TestCase):
              'c': [3, 4, 5, None, None],
              'd': [None, 8, 1, 3, None],
              'label': ['Y', 'N', 'Y', 'N', None]})
-        hcaihelpers.assert_dataframes_identical(expected, result)
+        assert_dataframes_identical(expected, result)
 
 
 class TestFeatureScaling(unittest.TestCase):
@@ -725,10 +727,10 @@ class TestFeatureScaling(unittest.TestCase):
         feature_scaling = transformers.DataFrameFeatureScaling()
         df_final = feature_scaling.fit_transform(self.df).round(5)
 
-        hcaihelpers.assert_dataframes_identical(expected.round(5), df_final)
+        assert_dataframes_identical(expected.round(5), df_final)
 
         df_reused = transformers.DataFrameFeatureScaling(reuse=feature_scaling).fit_transform(self.df_repeat).round(5)
-        hcaihelpers.assert_dataframes_identical(expected.round(5), df_reused)
+        assert_dataframes_identical(expected.round(5), df_reused)
 
 
 if __name__ == '__main__':

--- a/healthcareai/trained_models/trained_supervised_model.py
+++ b/healthcareai/trained_models/trained_supervised_model.py
@@ -202,7 +202,7 @@ class TrainedSupervisedModel(object):
         results[self.grain_column] = dataframe[self.grain_column].values
         results['Prediction'] = y_predictions
         results['Probability'] = y_probability
-        results['All Probabilities'] = str(all_probabilities)
+        results['All Probabilities'] = all_probabilities
 
         return results
 


### PR DESCRIPTION
## Things to test

- [ ] missing target column when predicting, still works on single and multiple row dataframes
- [ ] target column with `None`s, `np.NaN`s, or other unseen factors still works on single and multiple row dataframes
- [ ] Ensure you do not see the error specified in the issue #431