### PR TITLE
PLEASE MERGE SECOND :: Mutliclass predictions tested and fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ in console output and on ROC/PR plots.
 - Getting started section of README vastly improved
 - Bug that was imputing prediction target data during trainig.
 - Predictions no longer fail when categorical factors present during training were missing in prediction.
+- Nulls in prediction column are now removed
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `SupervisedModelTrainer` now has additional properties: `class_labels` and `number_of_classes`
 - new test helpers for robust dataframe and series equality assertions
 - DataFrameImputer can now exclude columns.
+- SupervisedModelTrainer now returns a nice dictionary of probabilites by label for multiclass predictions
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Imputation transformer now warns users about unseen factors during prediction use.
 - `SupervisedModelTrainer` now has additional properties: `class_labels` and `number_of_classes`
 - new test helpers for robust dataframe and series equality assertions
+- DataFrameImputer can now exclude columns.
 
 ### Changed
 

--- a/healthcareai/advanced_supvervised_model_trainer.py
+++ b/healthcareai/advanced_supvervised_model_trainer.py
@@ -516,10 +516,13 @@ class AdvancedSupervisedModelTrainer(object):
         # PEP 8
         test_set_predictions = None
         test_set_class_labels = None
+        class_labels = None
+
         if self.is_classification:
             # Save both the probabilities and labels
             test_set_predictions = algorithm.predict_proba(self.X_test)
             test_set_class_labels = algorithm.predict(self.X_test)
+            class_labels = self.class_labels
         elif self.is_regression:
             test_set_predictions = algorithm.predict(self.X_test)
 
@@ -540,6 +543,7 @@ class AdvancedSupervisedModelTrainer(object):
             test_set_class_labels=test_set_class_labels,
             test_set_actual=self.y_test,
             metric_by_name=self.metrics(algorithm),
+            class_labels=class_labels,
             original_column_names=self.original_column_names,
             categorical_column_info=self.categorical_column_info,
             training_time=time.time() - t0)

--- a/healthcareai/common/helpers.py
+++ b/healthcareai/common/helpers.py
@@ -1,6 +1,8 @@
 import math
 import sklearn
 
+from sklearn.grid_search import BaseSearchCV
+
 from healthcareai.common.healthcareai_error import HealthcareAIError
 
 
@@ -67,7 +69,8 @@ def extract_estimator_from_meta_estimator(model):
 
 def get_hyperparameters_from_meta_estimator(model):
     """
-    Given an instance of a trained sklearn estimator, return the best hyperparameters if it is a meta estimator
+    Given an instance of a trained sklearn estimator, return the best
+    hyperparameters if it is a meta estimator
     Args:
         model (sklearn.base.BaseEstimator): 
 
@@ -77,12 +80,20 @@ def get_hyperparameters_from_meta_estimator(model):
     if not issubclass(type(model), sklearn.base.BaseEstimator):
         raise HealthcareAIError('This requires an instance of sklearn.base.BaseEstimator')
 
-    if issubclass(type(model), sklearn.base.MetaEstimatorMixin):
+    if _is_randomized_search(model) or _is_grid_search(model):
         result = model.best_params_
     else:
         result = None
 
     return result
+
+
+def _is_grid_search(model):
+    return isinstance(model, sklearn.model_selection.GridSearchCV)
+
+
+def _is_randomized_search(model):
+    return isinstance(model, sklearn.model_selection.RandomizedSearchCV)
 
 
 if __name__ == '__main__':

--- a/healthcareai/pipelines/data_preparation.py
+++ b/healthcareai/pipelines/data_preparation.py
@@ -42,7 +42,7 @@ def training_pipeline(predicted_column, grain_column, impute=True):
         # TODO of rare and very predictive values
         # Perform one of two basic imputation methods
         # TODO we need to think about making this optional to solve the problem of rare and very predictive values
-        ('imputation', DataFrameImputer(impute=impute, verbose=True)),
+        ('imputation', DataFrameImputer(impute=impute, excluded_columns=predicted_column, verbose=True)),
         ('create_dummy_variables', DataFrameCreateDummyVariables(excluded_columns=[predicted_column])),
         ('null_row_filter', DataframeNullValueFilter(excluded_columns=None)),
     ])
@@ -79,7 +79,7 @@ def prediction_pipeline(predicted_column, grain_column):
         ('remove_grain_column', DataframeColumnRemover(grain_column)),
         # TODO we need to think about making this optional to solve the problem
         # TODO of rare and very predictive values
-        ('imputation', DataFrameImputer(impute=True)),
+        ('imputation', DataFrameImputer(impute=True, excluded_columns=predicted_column)),
         ('create_dummy_variables', DataFrameCreateDummyVariables(excluded_columns=[predicted_column])),
         ('null_row_filter', DataframeNullValueFilter(excluded_columns=[predicted_column])),
     ])

--- a/healthcareai/tests/helpers.py
+++ b/healthcareai/tests/helpers.py
@@ -30,8 +30,10 @@ def fixture(file):
 
 def assertBetween(self, minimum, maximum, value):
     """Fail if value is not between min and max (inclusive)."""
-    self.assertGreaterEqual(value, minimum)
-    self.assertLessEqual(value, maximum)
+    test_case = unittest.TestCase()
+
+    test_case.assertGreaterEqual(value, minimum)
+    test_case.assertLessEqual(value, maximum)
 
 
 def generate_known_numeric(length):

--- a/healthcareai/tests/test_advanced_trainer.py
+++ b/healthcareai/tests/test_advanced_trainer.py
@@ -228,7 +228,6 @@ class TestBinaryClassificationMetricValidation(unittest.TestCase):
         self.assertTrue(self.classification_trainer.is_binary_classification)
 
     def test_class_labels_strings(self):
-        # set literal saves a function call to set()
         self.assertEqual({'Y', 'N'}, set(self.classification_trainer.class_labels))
 
     def test_validate_score_metric_for_number_of_classes(self):

--- a/healthcareai/tests/test_advanced_trainer.py
+++ b/healthcareai/tests/test_advanced_trainer.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 import pandas as pd
 
-from healthcareai.advanced_supvervised_model_trainer import _remove_nas_from_labels
+from healthcareai.advanced_supvervised_model_trainer import _remove_nulls_from_labels
 from healthcareai.trained_models.trained_supervised_model import TrainedSupervisedModel
 import healthcareai.datasets as hcai_datasets
 
@@ -46,20 +46,29 @@ class TestAdvancedSupervisedModelTrainer(unittest.TestCase):
             clean_classification_df, CLASSIFICATION,
             CLS_PRED_COL)
 
-    def test_remove_nones_from_series(self):
+    def test_remove_nones_and_nans_from_object_series(self):
         ser = pd.Series(['Y', 'N', 'Y', np.NaN, None])
         expected = pd.Series(['Y', 'N', 'Y'])
 
-        result = _remove_nas_from_labels(ser)
+        result = _remove_nulls_from_labels(ser)
 
         self.assertIsInstance(result, pd.Series)
         pd.testing.assert_series_equal(expected, result)
+
+    def test_remove_nones_from_object_series(self):
+        junkpile = pd.Series(['Y', 'N', 'Y', None, None]).as_matrix()
+        expected = pd.Series(['Y', 'N', 'Y']).as_matrix()
+
+        result = _remove_nulls_from_labels(junkpile)
+
+        self.assertIsInstance(result, np.ndarray)
+        self.assertTrue(np.array_equal(expected, result))
 
     def test_remove_nones_from_numpy_array(self):
         arr = np.array([1, 2, 3, np.NaN, None])
         expected = np.array([1, 2, 3])
 
-        result = _remove_nas_from_labels(arr)
+        result = _remove_nulls_from_labels(arr)
 
         self.assertIsInstance(result, np.ndarray)
         self.assertTrue(np.array_equal(expected, result))
@@ -69,7 +78,7 @@ class TestAdvancedSupervisedModelTrainer(unittest.TestCase):
         index = pd.Categorical(['Y', 'N', 'Maybe', np.NaN, None])
         expected = pd.Index(['Maybe', 'N', 'Y'])
 
-        result = _remove_nas_from_labels(index)
+        result = _remove_nulls_from_labels(index)
 
         self.assertIsInstance(result, pd.Index)
         pd.testing.assert_index_equal(expected, result)
@@ -218,7 +227,7 @@ class TestBinaryClassificationMetricValidation(unittest.TestCase):
     def test_is_binary_classifier_true(self):
         self.assertTrue(self.classification_trainer.is_binary_classification)
 
-    def test_class_labels_property(self):
+    def test_class_labels_strings(self):
         # set literal saves a function call to set()
         self.assertEqual({'Y', 'N'}, set(self.classification_trainer.class_labels))
 

--- a/healthcareai/tests/test_dataframe_transformers.py
+++ b/healthcareai/tests/test_dataframe_transformers.py
@@ -6,7 +6,9 @@ import pandas as pd
 import random
 
 import healthcareai.common.transformers as transformers
-import healthcareai.tests.helpers as hcaihelpers
+from healthcareai.tests.helpers import generate_known_numeric, \
+    assert_dataframes_identical, convert_all_columns_to_uint8, \
+    assert_series_equal
 
 
 class TestDataframeImputer(unittest.TestCase):
@@ -24,7 +26,7 @@ class TestDataframeImputer(unittest.TestCase):
             'binary': np.random.choice(['a', 'b'], row_count, p=[.90, .1]),
             'alphabet': self.alphabet,
             'numeric': random.sample(range(0, row_count), row_count),
-            'known_numeric': hcaihelpers.generate_known_numeric(row_count),
+            'known_numeric': generate_known_numeric(row_count),
             'color': self.generate_known_color(row_count)
         })
         self.numeric_mean = self.train_df['numeric'].mean()
@@ -73,7 +75,7 @@ class TestDataframeImputer(unittest.TestCase):
         # Drop columns with unknown distributions
         result.drop(['id', 'alphabet'], inplace=True)
 
-        hcaihelpers.assert_series_equal(expected, result)
+        assert_series_equal(expected, result)
 
     def test_false_returns_unmodified(self):
         """Assure that no imputation occurs."""
@@ -94,7 +96,7 @@ class TestDataframeImputer(unittest.TestCase):
         imputer = transformers.DataFrameImputer(impute=False).fit(df)
         result = imputer.transform(df)
 
-        hcaihelpers.assert_dataframes_identical(expected, result)
+        assert_dataframes_identical(expected, result)
 
     def test_converts_object_to_category(self):
         df = pd.DataFrame({
@@ -108,7 +110,7 @@ class TestDataframeImputer(unittest.TestCase):
 
         result = transformers.DataFrameImputer().fit_transform(df)
 
-        hcaihelpers.assert_dataframes_identical(expected, result)
+        assert_dataframes_identical(expected, result)
 
     def test_columns_to_impute(self):
         result = self.imputer._columns_to_impute(self.train_df)
@@ -149,7 +151,7 @@ class TestDataframeImputer(unittest.TestCase):
         result = imputer.fit_transform(df)
 
         self.assertFalse(result['num1'].isnull().values.any())
-        _assert_dataframes_identical(expected, result)
+        assert_dataframes_identical(expected, result)
 
     def test_single_exclusion_as_list(self):
         df = pd.DataFrame({
@@ -170,7 +172,7 @@ class TestDataframeImputer(unittest.TestCase):
         result = imputer.fit_transform(df)
 
         self.assertFalse(result['num1'].isnull().values.any())
-        _assert_dataframes_identical(expected, result)
+        assert_dataframes_identical(expected, result)
 
     def test_removes_nans(self):
         """This should remove numeric NaNs, and not categoricals ones."""
@@ -192,7 +194,7 @@ class TestDataframeImputer(unittest.TestCase):
         self.assertFalse(result['num1'].isnull().values.any())
         self.assertFalse(result['num2'].isnull().values.any())
 
-        hcaihelpers.assert_dataframes_identical(expected, result)
+        assert_dataframes_identical(expected, result)
 
     def test_removes_nones(self):
         """This should remove numeric Nones, and not categorical ones."""
@@ -215,7 +217,7 @@ class TestDataframeImputer(unittest.TestCase):
         self.assertFalse(result['num1'].isnull().values.any())
         self.assertFalse(result['num2'].isnull().values.any())
 
-        hcaihelpers.assert_dataframes_identical(expected, result)
+        assert_dataframes_identical(expected, result)
 
     def test_get_unseen_factors(self):
         """binary column is as expected and alphabet column has new levels."""
@@ -357,7 +359,7 @@ class TestDataframeImputer(unittest.TestCase):
         # imputer = transformers.DataFrameImputer().fit(prediction_df)
         result = self.imputer.transform(prediction_df)
 
-        hcaihelpers.assert_dataframes_identical(expected, result)
+        assert_dataframes_identical(expected, result)
 
 
 class TestDataFrameConvertTargetToBinary(unittest.TestCase):
@@ -371,7 +373,7 @@ class TestDataFrameConvertTargetToBinary(unittest.TestCase):
 
         result = transformers.DataFrameConvertTargetToBinary('regression', 'string_outcome').fit_transform(expected)
 
-        hcaihelpers.assert_dataframes_identical(expected, result)
+        assert_dataframes_identical(expected, result)
 
     def test_converts_y_n_for_classification(self):
         df = pd.DataFrame({
@@ -390,7 +392,7 @@ class TestDataFrameConvertTargetToBinary(unittest.TestCase):
 
         result = transformers.DataFrameConvertTargetToBinary('classification', 'string_outcome').fit_transform(df)
 
-        hcaihelpers.assert_dataframes_identical(expected, result)
+        assert_dataframes_identical(expected, result)
 
 
 class TestDataFrameCreateDummyVariables(unittest.TestCase):
@@ -459,7 +461,7 @@ class TestDataFrameCreateDummyVariables(unittest.TestCase):
 
         result = dummifier.transform(df)
 
-        hcaihelpers.assert_dataframes_identical(expected, result)
+        assert_dataframes_identical(expected, result)
 
     def test_trinary_object_and_category(self):
         df = pd.DataFrame({
@@ -491,7 +493,7 @@ class TestDataFrameCreateDummyVariables(unittest.TestCase):
         result = transformers.DataFrameCreateDummyVariables(
             'id').fit_transform(df)
 
-        hcaihelpers.assert_dataframes_identical(expected, result)
+        assert_dataframes_identical(expected, result)
 
     def test_remembers_unrepresented_categories(self):
         # TODO this is broken due to a pandas bug
@@ -529,7 +531,7 @@ class TestDataFrameCreateDummyVariables(unittest.TestCase):
         # trained = transformers.DataFrameCreateDummyVariables('id').fit(self.train_df)
         # result = trained.transform(prediction_df)
         #
-        # hcaihelpers._assert_dataframes_identical(expected, result)
+        # _assert_dataframes_identical(expected, result)
 
     def test_none_represented(self):
         prediction_df = pd.DataFrame({
@@ -572,10 +574,10 @@ class TestDataFrameCreateDummyVariables(unittest.TestCase):
             'numeric': [1, 2, 1],
         })
 
-        expected = hcaihelpers.convert_all_columns_to_uint8(expected, ['id', 'numeric'])
+        expected = convert_all_columns_to_uint8(expected, ['id', 'numeric'])
         result = self.dummifier.transform(prediction_df)
 
-        hcaihelpers.assert_dataframes_identical(expected, result)
+        assert_dataframes_identical(expected, result)
 
 
 class TestDataFrameConvertColumnToNumeric(unittest.TestCase):
@@ -592,7 +594,7 @@ class TestDataFrameConvertColumnToNumeric(unittest.TestCase):
         })
 
         result = transformers.DataFrameConvertColumnToNumeric('integer_strings').fit_transform(df)
-        hcaihelpers.assert_dataframes_identical(expected, result)
+        assert_dataframes_identical(expected, result)
 
     def test_integer(self):
         df = pd.DataFrame({
@@ -606,7 +608,7 @@ class TestDataFrameConvertColumnToNumeric(unittest.TestCase):
 
         result = transformers.DataFrameConvertColumnToNumeric('numeric').fit_transform(df)
 
-        hcaihelpers.assert_dataframes_identical(expected, result)
+        assert_dataframes_identical(expected, result)
 
 
 class TestDataframeUnderSampler(unittest.TestCase):
@@ -695,7 +697,7 @@ class TestRemovesNANs(unittest.TestCase):
              'c': [3, 4, 5, None, None],
              'd': [None, 8, 1, 3, None],
              'label': ['Y', 'N', 'Y', 'N', None]})
-        hcaihelpers.assert_dataframes_identical(expected, result)
+        assert_dataframes_identical(expected, result)
 
 
 class TestFeatureScaling(unittest.TestCase):
@@ -725,10 +727,10 @@ class TestFeatureScaling(unittest.TestCase):
         feature_scaling = transformers.DataFrameFeatureScaling()
         df_final = feature_scaling.fit_transform(self.df).round(5)
 
-        hcaihelpers.assert_dataframes_identical(expected.round(5), df_final)
+        assert_dataframes_identical(expected.round(5), df_final)
 
         df_reused = transformers.DataFrameFeatureScaling(reuse=feature_scaling).fit_transform(self.df_repeat).round(5)
-        hcaihelpers.assert_dataframes_identical(expected.round(5), df_reused)
+        assert_dataframes_identical(expected.round(5), df_reused)
 
 
 if __name__ == '__main__':

--- a/healthcareai/tests/test_model_eval_helpers.py
+++ b/healthcareai/tests/test_model_eval_helpers.py
@@ -1,6 +1,67 @@
 import unittest
-from healthcareai.common.helpers import calculate_random_forest_mtry_hyperparameter
+from healthcareai.common.helpers import \
+    calculate_random_forest_mtry_hyperparameter, \
+    get_hyperparameters_from_meta_estimator
 from healthcareai.common.healthcareai_error import HealthcareAIError
+
+
+class TestHyperparameterExtractor(unittest.TestCase):
+    def test_raise_errors_on_junk_input(self):
+        for junk in [None, 'foo', 33]:
+            self.assertRaises(
+                HealthcareAIError,
+                get_hyperparameters_from_meta_estimator,
+                junk)
+
+    def test_returns_none_if_not_meta_estimator(self):
+        from sklearn.base import BaseEstimator
+        e = BaseEstimator()
+
+        self.assertIsNone(get_hyperparameters_from_meta_estimator(e))
+
+    def test_return_hyperparams_if_randomized_search(self):
+        from sklearn.neighbors import KNeighborsClassifier
+        from sklearn.model_selection import RandomizedSearchCV
+
+        x, y = _small_dataset()
+
+        algo = RandomizedSearchCV(
+            estimator=KNeighborsClassifier(),
+            scoring='accuracy',
+            param_distributions={'n_neighbors': [1, 5]},
+            n_iter=2,
+            verbose=0,
+            n_jobs=1)
+        algo.fit(x, y)
+
+        observed = get_hyperparameters_from_meta_estimator(algo)
+
+        self.assertIsInstance(observed, dict)
+        self.assertTrue('n_neighbors' in observed.keys())
+
+    def test_return_hyperparams_if_grid_search(self):
+        from sklearn.neighbors import KNeighborsClassifier
+        from sklearn.model_selection import GridSearchCV
+
+        x, y = _small_dataset()
+
+        algo = GridSearchCV(
+            estimator=KNeighborsClassifier(),
+            scoring='accuracy',
+            param_grid={'n_neighbors': [1, 5]},
+            verbose=0,
+            n_jobs=1)
+        algo.fit(x, y)
+
+        observed = get_hyperparameters_from_meta_estimator(algo)
+        self.assertIsInstance(observed, dict)
+        self.assertTrue('n_neighbors' in observed.keys())
+
+    def test_returns_none_if_random_forest(self):
+        from sklearn.ensemble import RandomForestClassifier
+        rf = RandomForestClassifier()
+
+        self.assertIsNone(get_hyperparameters_from_meta_estimator(rf))
 
 
 class TestCalculateRandomForestCalculateMTry(unittest.TestCase):
@@ -66,6 +127,16 @@ class TestCalculateRandomForestCalculateMTry(unittest.TestCase):
         result = calculate_random_forest_mtry_hyperparameter(100, 'regression')
         self.assertEqual(result, [32, 33, 34])
 
+
+def _small_dataset():
+    import healthcareai
+    df = healthcareai.load_diabetes()[:100]
+    df.drop(['PatientID'], axis=1, inplace=True)
+    df.dropna(inplace=True)
+    df['ThirtyDayReadmitFLG'].fillna('N', inplace=True)
+    x = df[['SystolicBPNBR']].as_matrix()
+    y = df['ThirtyDayReadmitFLG'].as_matrix()
+    return x, y
 
 if __name__ == '__main__':
     unittest.main()

--- a/healthcareai/tests/test_multiclass_probability_compactor.py
+++ b/healthcareai/tests/test_multiclass_probability_compactor.py
@@ -1,0 +1,71 @@
+import unittest
+
+import numpy as np
+
+from healthcareai.common.healthcareai_error import HealthcareAIError
+from healthcareai.trained_models.trained_supervised_model import \
+    _max_probability_extractor, _probabilities_by_label
+
+
+class TestProbabilitesByLabel(unittest.TestCase):
+    def test_returns_list(self):
+        self.assertIsInstance(_probabilities_by_label(None, None), list)
+
+    def test_raise_error_if_column_number_unequal_to_labels(self):
+        labels = ['a', 'b']
+        matrix = np.array([
+            [1, 2, 3]
+        ])
+
+        self.assertRaises(
+            HealthcareAIError,
+            _probabilities_by_label,
+            labels,
+            matrix
+        )
+
+    def test_one_for_one(self):
+        expected = [{'a': 1, 'b': 7}]
+
+        labels = ['a', 'b']
+        matrix = np.array([
+            [1, 7]
+        ])
+        observed = _probabilities_by_label(labels, matrix)
+
+        self.assertEqual(expected, observed)
+
+    def test_three_by_four(self):
+        expected = [
+            {'a': 3, 'b': 5, 'c': 4, 'd': 1},
+            {'a': 5, 'b': 4, 'c': 1, 'd': 0},
+            {'a': 3, 'b': 5, 'c': 4, 'd': 1},
+            {'a': 3, 'b': 5, 'c': 4, 'd': 1},
+        ]
+
+        labels = ['a', 'b', 'c', 'd']
+        matrix = np.array([
+            [3, 5, 4, 1],
+            [5, 4, 1, 0],
+            [3, 5, 4, 1],
+            [3, 5, 4, 1]
+        ])
+        observed = _probabilities_by_label(labels, matrix)
+
+        self.assertEqual(expected, observed)
+
+
+class TestMaxProbabilityExtractor(unittest.TestCase):
+    def test_max_of_one(self):
+        stuff = {'a': 33}
+        observed = _max_probability_extractor(stuff)
+
+        self.assertIsInstance(observed, (int, float))
+        self.assertEqual(33, observed)
+
+    def test_max_of_many(self):
+        stuff = {'a': 33, 'b': 99, 'c': 0, 'd': 98.99}
+        observed = _max_probability_extractor(stuff)
+
+        self.assertIsInstance(observed, (int, float))
+        self.assertEqual(99, observed)

--- a/healthcareai/tests/test_trained_supervised_model.py
+++ b/healthcareai/tests/test_trained_supervised_model.py
@@ -77,8 +77,11 @@ class TestTrainedSupervisedModel(unittest.TestCase):
         self.assertTrue(self.trained_lr.is_binary_classification)
         self.assertFalse(self.trained_linear.is_binary_classification)
 
-    def test_class_labels(self):
-        self.assertListEqual(['N', 'Y'], list(self.trained_lr._class_labels))
+    def test_class_labels_correct(self):
+        self.assertListEqual(['N', 'Y'], list(self.trained_lr.class_labels))
+
+    def test_class_labels_none_on_regressor(self):
+        self.assertIsNone(self.trained_linear.class_labels)
 
     def test_predictions_is_dataframe(self):
         self.assertIsInstance(self.predictions, pd.core.frame.DataFrame)

--- a/healthcareai/tests/test_trained_supervised_model.py
+++ b/healthcareai/tests/test_trained_supervised_model.py
@@ -77,6 +77,9 @@ class TestTrainedSupervisedModel(unittest.TestCase):
         self.assertTrue(self.trained_lr.is_binary_classification)
         self.assertFalse(self.trained_linear.is_binary_classification)
 
+    def test_class_labels(self):
+        self.assertListEqual(['N', 'Y'], list(self.trained_lr._class_labels))
+
     def test_predictions_is_dataframe(self):
         self.assertIsInstance(self.predictions, pd.core.frame.DataFrame)
 

--- a/healthcareai/trained_models/trained_supervised_model.py
+++ b/healthcareai/trained_models/trained_supervised_model.py
@@ -169,42 +169,44 @@ class TrainedSupervisedModel(object):
             dataframe (pandas.core.frame.DataFrame): Raw prediction dataframe
 
         Returns:
-            pandas.core.frame.DataFrame: A dataframe containing the grain id and predicted values
+            pandas.core.frame.DataFrame: A dataframe containing the grain id
+            and predicted values
+
+        Raises:
+            HealthcareAIError: Model neither regressor or classifier.
         """
-        # Run the raw dataframe through the preparation process
-        prepared_dataframe = self.prepare_and_subset(dataframe)
+        self._validate_regressor_or_classifier()
+        df = self.prepare_and_subset(dataframe)
 
-        y_predictions = None
-        y_probability = None
-        all_probabilities = None
+        result = pd.DataFrame({
+            self.grain_column: dataframe[self.grain_column].values,
+            'Prediction': None,
+            'Probability': None,
+            'All Probabilities': None
+        })
 
-        # make predictions returning probabity of a class or value of regression
-        if self.is_binary_classification():
+        if self.is_binary_classification:
             # Only save the prediction of one of the two classes
-            y_predictions = self.model.predict_proba(prepared_dataframe)[:, 1]
+            result['Prediction'] = self.model.predict_proba(df)[:, 1]
         elif self.is_classification:
-            # TODO This needs further thought. Should the prediction column
-            # TODO stay numeric and add an additional class object column?
-            # TODO fix all the tests
-            y_predictions = self.model.predict(prepared_dataframe)
-            all_probabilities = self.model.predict_proba(prepared_dataframe)
+            result['Prediction'] = self.model.predict(df)
+            probs_by_label = _probabilities_by_label(
+                self.model.classes_,
+                self.model.predict_proba(df))
+            result['All Probabilities'] = probs_by_label
 
             # retrieve the probability of the single predicted class label
-            all_probabilities = {k: v for k, v in zip(self.model.classes_, np.squeeze(all_probabilities))}
-            y_probability = all_probabilities[y_predictions[0]]
+            result['Probability'] = _get_max_probabilities(probs_by_label)
         elif self.is_regression:
-            y_predictions = self.model.predict(prepared_dataframe)
-        else:
-            raise HealthcareAIError('Model type appears to be neither regression or classification.')
+            result['Prediction'] = self.model.predict(df)
 
-        # Create a new dataframe with the grain column from the original dataframe
-        results = pd.DataFrame()
-        results[self.grain_column] = dataframe[self.grain_column].values
-        results['Prediction'] = y_predictions
-        results['Probability'] = y_probability
-        results['All Probabilities'] = all_probabilities
+        return result
 
-        return results
+    def _validate_regressor_or_classifier(self):
+        if not self.is_classification and not self.is_regression:
+            raise HealthcareAIError(
+                'Model type appears to be neither regression or '
+                'classification.')
 
     def prepare_and_subset(self, dataframe):
         """
@@ -582,7 +584,7 @@ class TrainedSupervisedModel(object):
     def roc_plot(self):
         """Plot the ROC curve of the holdout set from model training."""
         self._validate_classification()
-        if not self.is_binary_classification():
+        if not self.is_binary_classification:
             raise HealthcareAIError('ROC plots only work for binary classification (\'Y\'/\'N\').\n'
                                     'For multiple classes (\'DRG1\'/\'DRG2\'/\'DRG3\'/...) use the '
                                     'confusion matrix instead.')
@@ -643,7 +645,7 @@ class TrainedSupervisedModel(object):
     def pr_plot(self):
         """Plot the PR curve of the holdout set from model training."""
         self._validate_classification()
-        if not self.is_binary_classification():
+        if not self.is_binary_classification:
             raise HealthcareAIError('PR plots only work for binary classification (\'Y\'/\'N\').\n'
                                     'For multiple classes (\'red\'/\'green\'/\'blue\'/...) use the '
                                     'confusion matrix instead.')
@@ -713,9 +715,10 @@ class TrainedSupervisedModel(object):
 
         Run this in any method that only makes sense for binary classification.
         """
-        if not self.is_binary_classification():
+        if not self.is_binary_classification:
             raise HealthcareAIError('This function only runs on a binary classification model.')
 
+    @property
     def is_binary_classification(self):
         """
         Check if an instance is a binary classifier.
@@ -813,7 +816,7 @@ def tsm_classification_comparison_plots(trained_supervised_models, plot_type='RO
             if not isinstance(model, TrainedSupervisedModel):
                 raise HealthcareAIError('One of the objects in the list is not a TrainedSupervisedModel ({})'
                                         .format(model))
-            if not model.is_binary_classification():
+            if not model.is_binary_classification:
                 raise HealthcareAIError(
                     'Comparison plots only work for binary classification tasks.')
 
@@ -857,7 +860,8 @@ def _confusion_matrix_text_color(normalize, value, threshold):
     """
     Determine the appropriate color for text on the confusion matrix plot.
     
-    If it is not normalized, keep text black. If it is normalized, use white when it is beyond the threshold.
+    If it is not normalized, keep text black. If it is normalized, use white
+    when it is beyond the threshold.
     
     Args:
         normalize (bool): if the plot is normalized
@@ -872,3 +876,47 @@ def _confusion_matrix_text_color(normalize, value, threshold):
         return 'black'
 
     return 'white' if value > threshold else 'black'
+
+
+def _probabilities_by_label(labels, matrix):
+    """
+    Build a list of dictionaries containing probabilities by label.
+
+    Args:
+        labels (list): List of class labels
+        matrix (np.array): 2D array of class probabilites by row
+
+    Returns:
+        list: list of dictionaries
+
+    Raises:
+        HealthcareAIError: Wrong number of labels.
+    """
+    compacted = []
+
+    if labels is None or matrix is None:
+        return compacted
+
+    _validate_label_count(labels, matrix)
+
+    for x in matrix:
+        compacted.append({k: v for k, v in zip(labels, x)})
+
+    return compacted
+
+
+def _validate_label_count(labels, matrix):
+    """Validate label count matches column count."""
+    if len(labels) != len(matrix[0]):
+        raise HealthcareAIError('Number of labels does not match columns.')
+
+
+def _get_max_probabilities(probs_by_label):
+    """Get all max probabilities."""
+    return [_max_probability_extractor(x) for x in probs_by_label]
+
+
+def _max_probability_extractor(probabilites_by_label):
+    """Extract the max probability from a dict of probabilities by label."""
+    max_key = max(probabilites_by_label, key=probabilites_by_label.get)
+    return probabilites_by_label[max_key]

--- a/healthcareai/trained_models/trained_supervised_model.py
+++ b/healthcareai/trained_models/trained_supervised_model.py
@@ -202,7 +202,7 @@ class TrainedSupervisedModel(object):
         results[self.grain_column] = dataframe[self.grain_column].values
         results['Prediction'] = y_predictions
         results['Probability'] = y_probability
-        results['All Probabilities'] = str(all_probabilities)
+        results['All Probabilities'] = all_probabilities
 
         return results
 


### PR DESCRIPTION
## Background

- It was discovered that the multiclass predictions were not nearly as robust as they needed to be.

## Minimal script to test

```
import healthcareai

dataframe = healthcareai.load_dermatology()
df = dataframe.copy()

print(dataframe.head(5))

dataframe.drop(['target_num'], axis=1, inplace=True)

classification_trainer = healthcareai.SupervisedModelTrainer(
    dataframe,
    predicted_column='target_str',
    model_type='classification',
    grain_column='PatientID',
    impute=True)

trained_lr = classification_trainer.logistic_regression()

preds = trained_lr.make_predictions(df)
print(preds)
```